### PR TITLE
feat: pass request context and node address to the events sink adapter

### DIFF
--- a/cmd/siderolink-agent/event_sink.go
+++ b/cmd/siderolink-agent/event_sink.go
@@ -25,13 +25,13 @@ var eventSinkFlags struct {
 type adapter struct{}
 
 // HandleEvent implements events.Adapter.
-func (s *adapter) HandleEvent(e events.Event) error {
+func (s *adapter) HandleEvent(ctx context.Context, e events.Event) error {
 	data, err := yaml.Marshal(e.Payload)
 	if err != nil {
 		return err
 	}
 
-	log.Printf("Event: %s, ID: %s, Payload: \n\t%s", e.TypeURL, e.ID, strings.Join(strings.Split(string(data), "\n"), "\n\t"))
+	log.Printf("Node: %s, Event: %s, ID: %s, Payload: \n\t%s", e.Node, e.TypeURL, e.ID, strings.Join(strings.Split(string(data), "\n"), "\n\t"))
 
 	return nil
 }

--- a/pkg/events/event.go
+++ b/pkg/events/event.go
@@ -12,4 +12,5 @@ type Event struct {
 	Payload proto.Message
 	TypeURL string
 	ID      string
+	Node    string
 }

--- a/pkg/events/sink_test.go
+++ b/pkg/events/sink_test.go
@@ -36,9 +36,13 @@ type state struct {
 }
 
 // HandleEvent implements events.Adapter.
-func (s *state) HandleEvent(e events.Event) error {
+func (s *state) HandleEvent(ctx context.Context, e events.Event) error {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
+
+	if e.Node == "" {
+		return fmt.Errorf("node address information is empty")
+	}
 
 	switch msg := e.Payload.(type) {
 	case *machine.AddressEvent:


### PR DESCRIPTION
Context may be handy to cancel any subsequent calls in the adapter.
While node Addr is required in Sidero to match nodes.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>